### PR TITLE
fix: ESM `import()` compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install
         run: nci
 
+      - name: Build
+        run: nr build
+
       - name: Typecheck
         run: nr typecheck
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.cjs"
     },
     "./worker": {
       "require": "./dist/worker.cjs"

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,0 +1,25 @@
+import { createRequire } from "node:module";
+
+import { expect, it } from "vitest";
+
+it("should be importable", async () => {
+  const imported = await import("..");
+
+  expect(imported).toMatchObject({
+    parsers: {},
+  });
+});
+
+it("should be requireable", () => {
+  const imported = createRequire(import.meta.url)("..");
+
+  expect(imported).toMatchObject({
+    parsers: {},
+  });
+});
+
+it("should be resolvable", () => {
+  const imported = require.resolve("..");
+
+  expect(imported).toMatch(/prettier-plugin-pkgsort\/dist\/index.cjs/);
+});

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -21,5 +21,5 @@ it("should be requireable", () => {
 it("should be resolvable", () => {
   const imported = require.resolve("..");
 
-  expect(imported).toMatch(/prettier-plugin-pkgsort\/dist\/index.cjs/);
+  expect(imported).toMatch(/prettier-plugin-pkgsort[/\\]dist[/\\]index.cjs$/);
 });


### PR DESCRIPTION
Fixes https://github.com/so1ve/prettier-plugin-pkgsort/issues/24

