### PR TITLE
test: more precise way to assert resolved path to plugin

### DIFF
--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 import { expect, it } from "vitest";
 
@@ -19,7 +20,11 @@ it("should be requireable", () => {
 });
 
 it("should be resolvable", () => {
-	const imported = require.resolve("..");
+	const actualPath = fileURLToPath(
+		new URL("../dist/index.cjs", import.meta.url),
+	);
 
-	expect(imported).toMatch(/prettier-plugin-pkgsort[/\\]dist[/\\]index.cjs$/);
+	const resolved = require.resolve("..");
+
+	expect(resolved).toEqual(actualPath);
 });


### PR DESCRIPTION
Sorry, I just suddenly remembered that I put hardcoded project folder name to tests. This test case will fail if somebody will clone repo to folder with different name

https://github.com/so1ve/prettier-plugin-pkgsort/blob/6b22c3cb73170a28febe7d9bb2a1e91bdf344d5d/test/package.test.ts#L24

<sub>~~I hope `new URL("../dist/index.cjs", import.meta.url)` won't fail on Windows~~
upd: it works!</sub>